### PR TITLE
fix: add missing modules and remove unused modules

### DIFF
--- a/humanomni/mm_utils.py
+++ b/humanomni/mm_utils.py
@@ -11,12 +11,8 @@ import imageio
 import numpy as np
 from PIL import Image
 from decord import VideoReader, cpu, AudioReader
-from moviepy.editor import VideoFileClip
 from transformers import StoppingCriteria
-import random
-from .constants import NUM_FRAMES, MAX_FRAMES, NUM_FRAMES_PER_SECOND, MODAL_INDEX_MAP, DEFAULT_IMAGE_TOKEN
-import concurrent.futures
-import ipdb
+from .constants import NUM_FRAMES, NUM_FRAMES_PER_SECOND, MODAL_INDEX_MAP, DEFAULT_IMAGE_TOKEN
 
 def chunk_list(input_list, chunk_size):
     return [input_list[i:i + chunk_size] for i in range(0, len(input_list), chunk_size)]

--- a/humanomni/model/humanomni_arch.py
+++ b/humanomni/model/humanomni_arch.py
@@ -23,12 +23,8 @@ import torch.nn as nn
 import torch.nn.functional as F
 from .projector import load_mm_projector, build_vision_projector, build_audio_projector
 from .encoder import build_vision_tower, build_audio_tower
-from ..constants import IGNORE_INDEX, NUM_FRAMES, MODAL_INDEX_MAP, IMAGE_TOKEN_PATCH, MODAL_INDEX_REMAP
-from humanomni.mm_utils import frame_sample
+from ..constants import IGNORE_INDEX, NUM_FRAMES, MODAL_INDEX_MAP, MODAL_INDEX_REMAP
 from transformers import BertModel, BertTokenizer
-import h5py
-import torch.distributed as dist
-import ipdb
 
 class SFDynamicCompressor(nn.Module):
     def __init__(self, model_args, vision_tower):

--- a/setup.sh
+++ b/setup.sh
@@ -3,6 +3,7 @@ cd src/r1-v
 pip install -e ".[dev]"
 
 # Addtional modules
+pip install opencv-python timm imageio decord
 # pip install wandb==0.18.3
 # pip install tensorboardx
 # pip install qwen_vl_utils torchvision


### PR DESCRIPTION
After installing according to `setup.sh`, there are still some missing packages for HumanOmni and many redundant imports during reasoning.
This PR add the install command to `setup.sh` and remove unused modules.